### PR TITLE
Add gill-based Anchor tests

### DIFF
--- a/templates/template-next-tailwind-basic/anchor/tests/basic.test.ts
+++ b/templates/template-next-tailwind-basic/anchor/tests/basic.test.ts
@@ -1,7 +1,41 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  appendTransactionMessageInstruction,
+  createSolanaClient,
+  createTransactionMessage,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signAndSendTransactionMessageWithSigners,
+} from 'gill'
+import { loadKeypairSignerFromFile } from 'gill/node'
+import { getGreetInstruction } from '@project/anchor'
+
 describe('basic', () => {
-  // TODO: Implement tests for the basic program based on the Codama generated client.
-  // Use tests in `legacy/legacy-next-tailwind-basic/anchor/tests/basic.test.ts` as a reference.
+  const anchorToml = fs.readFileSync(path.resolve(__dirname, '..', 'Anchor.toml'), 'utf8')
+  const walletMatch = anchorToml.match(/wallet\s*=\s*"([^"]+)"/)
+  const walletPath = walletMatch ? walletMatch[1].replace(/^~(?=\/)/, os.homedir()) : ''
+
+  const client = createSolanaClient({ urlOrMoniker: 'localnet' })
+  let signer: Awaited<ReturnType<typeof loadKeypairSignerFromFile>>
+
+  beforeAll(async () => {
+    signer = await loadKeypairSignerFromFile(walletPath)
+  })
+
   it('should run the program and print "GM!" to the transaction log', async () => {
-    expect(true).toBe(true)
+    const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(signer, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
+      (m) => appendTransactionMessageInstruction(getGreetInstruction(), m),
+    )
+
+    const signature = await signAndSendTransactionMessageWithSigners(message)
+    const tx = await client.rpc.getTransaction(signature).send()
+    expect(tx.meta?.logMessages?.some((l) => l.includes('GM!'))).toBe(true)
   })
 })

--- a/templates/template-next-tailwind-basic/anchor/tests/basic.test.ts
+++ b/templates/template-next-tailwind-basic/anchor/tests/basic.test.ts
@@ -1,6 +1,17 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+
+function getWalletPath() {
+  const fromEnv = process.env.ANCHOR_WALLET
+  if (fromEnv) return fromEnv.replace(/^~(?=\/)/, os.homedir())
+  const anchorToml = fs.readFileSync(
+    path.resolve(__dirname, '..', 'Anchor.toml'),
+    'utf8',
+  )
+  const match = anchorToml.match(/wallet\s*=\s*"([^"]+)"/)
+  return match ? match[1].replace(/^~(?=\/)/, os.homedir()) : ''
+}
 import {
   appendTransactionMessageInstruction,
   createSolanaClient,
@@ -14,9 +25,7 @@ import { loadKeypairSignerFromFile } from 'gill/node'
 import { getGreetInstruction } from '@project/anchor'
 
 describe('basic', () => {
-  const anchorToml = fs.readFileSync(path.resolve(__dirname, '..', 'Anchor.toml'), 'utf8')
-  const walletMatch = anchorToml.match(/wallet\s*=\s*"([^"]+)"/)
-  const walletPath = walletMatch ? walletMatch[1].replace(/^~(?=\/)/, os.homedir()) : ''
+  const walletPath = getWalletPath()
 
   const client = createSolanaClient({ urlOrMoniker: 'localnet' })
   let signer: Awaited<ReturnType<typeof loadKeypairSignerFromFile>>

--- a/templates/template-next-tailwind-counter/anchor/tests/counter.test.ts
+++ b/templates/template-next-tailwind-counter/anchor/tests/counter.test.ts
@@ -1,27 +1,89 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  appendTransactionMessageInstruction,
+  createSolanaClient,
+  createTransactionMessage,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signAndSendTransactionMessageWithSigners,
+} from 'gill'
+import {
+  generateExtractableKeyPairSigner,
+  loadKeypairSignerFromFile,
+} from 'gill/node'
+import {
+  fetchMaybeCounter,
+  fetchCounter,
+  getCloseInstruction,
+  getDecrementInstruction,
+  getIncrementInstruction,
+  getInitializeInstruction,
+  getSetInstruction,
+} from '@project/anchor'
+
 describe('counter', () => {
-  // TODO: Implement tests for the counter program based on the Codama generated client.
-  // Use tests in `legacy/legacy-next-tailwind-counter/anchor/tests/counter.test.ts` as a reference.
-  it.skip('Initialize Counter', async () => {
-    expect(true).toBe(true)
+  const anchorToml = fs.readFileSync(path.resolve(__dirname, '..', 'Anchor.toml'), 'utf8')
+  const walletMatch = anchorToml.match(/wallet\s*=\s*"([^"]+)"/)
+  const walletPath = walletMatch ? walletMatch[1].replace(/^~(?=\/)/, os.homedir()) : ''
+
+  const client = createSolanaClient({ urlOrMoniker: 'localnet' })
+  let payer: Awaited<ReturnType<typeof loadKeypairSignerFromFile>>
+  let counterSigner: Awaited<ReturnType<typeof generateExtractableKeyPairSigner>>
+
+  beforeAll(async () => {
+    payer = await loadKeypairSignerFromFile(walletPath)
+    counterSigner = await generateExtractableKeyPairSigner()
   })
 
-  it.skip('Increment Counter', async () => {
-    expect(true).toBe(true)
+  async function send(ix: Parameters<typeof appendTransactionMessageInstruction>[0]) {
+    const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(payer, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
+      (m) => appendTransactionMessageInstruction(ix, m),
+    )
+    await signAndSendTransactionMessageWithSigners(message)
+  }
+
+  it('Initialize Counter', async () => {
+    await send(
+      getInitializeInstruction({ payer, counter: counterSigner })
+    )
+    const account = await fetchCounter(client.rpc, counterSigner.address)
+    expect(account.data.count).toBe(0)
   })
 
-  it.skip('Increment Counter Again', async () => {
-    expect(true).toBe(true)
+  it('Increment Counter', async () => {
+    await send(getIncrementInstruction({ counter: counterSigner.address }))
+    const account = await fetchCounter(client.rpc, counterSigner.address)
+    expect(account.data.count).toBe(1)
   })
 
-  it.skip('Decrement Counter', async () => {
-    expect(true).toBe(true)
+  it('Increment Counter Again', async () => {
+    await send(getIncrementInstruction({ counter: counterSigner.address }))
+    const account = await fetchCounter(client.rpc, counterSigner.address)
+    expect(account.data.count).toBe(2)
   })
 
-  it.skip('Set counter value', async () => {
-    expect(true).toBe(true)
+  it('Decrement Counter', async () => {
+    await send(getDecrementInstruction({ counter: counterSigner.address }))
+    const account = await fetchCounter(client.rpc, counterSigner.address)
+    expect(account.data.count).toBe(1)
   })
 
-  it.skip('Set close the counter account', async () => {
-    expect(true).toBe(true)
+  it('Set counter value', async () => {
+    await send(getSetInstruction({ counter: counterSigner.address, value: 42 }))
+    const account = await fetchCounter(client.rpc, counterSigner.address)
+    expect(account.data.count).toBe(42)
+  })
+
+  it('Set close the counter account', async () => {
+    await send(getCloseInstruction({ payer, counter: counterSigner.address }))
+    const account = await fetchMaybeCounter(client.rpc, counterSigner.address)
+    expect(account && 'exists' in account ? account.exists : account === null).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- implement basic and counter program tests that utilize gill
- connect to the local validator via gill and send transactions
- fetch accounts using Codama generated client helpers

## Testing
- `cargo install --locked --git https://github.com/coral-xyz/anchor anchor-cli --tag v0.31.1` *(fails: long compilation, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6879fd6609b48328ba92774d73217fc3